### PR TITLE
fix: changed default aios kernel url

### DIFF
--- a/cerebrum/example/run_agent.py
+++ b/cerebrum/example/run_agent.py
@@ -124,6 +124,7 @@ def main():
     )
     parser.add_argument(
         "--aios_kernel_url",
+        default = "https://127.0.0.1:8000",
         required=True
     )
 

--- a/cerebrum/example/run_agent.py
+++ b/cerebrum/example/run_agent.py
@@ -124,7 +124,7 @@ def main():
     )
     parser.add_argument(
         "--aios_kernel_url",
-        default = "https://127.0.0.1:8000",
+        default = "http://127.0.0.1:8000",
         required=True
     )
 


### PR DESCRIPTION
Changed the AIOS kernel default url because this is more compatible with more machines as 127.0.0.1 is a loopback address. Also standardized the default parameter for this argument.