### PR TITLE
fixed cannot import name 'get_from_env' from 'cerebrum.utils'

### DIFF
--- a/cerebrum/utils/__init__.py
+++ b/cerebrum/utils/__init__.py
@@ -1,0 +1,5 @@
+from .utils import get_from_env
+
+__all__ = [
+    'get_from_env',
+]


### PR DESCRIPTION
While using cerebrum tools inside AIOS was getting above error, fixed it